### PR TITLE
Fixes issue #167 - Fix build with JDK 15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,13 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>clirr-maven-plugin</artifactId>
                     <version>2.8</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.bcel</groupId>
+                            <artifactId>bcel</artifactId>
+                            <version>6.5.0</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>


### PR DESCRIPTION
Fixes #167 

The version of Bcel that the Clirr maven plugin uses doesn't support newer bytecode.